### PR TITLE
Android Permission Bus PoC

### DIFF
--- a/appa/build.gradle
+++ b/appa/build.gradle
@@ -1,0 +1,22 @@
+plugins {
+    id 'com.android.application'
+}
+
+android {
+    namespace 'com.example.appa'
+    compileSdk 34
+
+    defaultConfig {
+        applicationId 'com.example.appa'
+        minSdk 21
+        targetSdk 34
+        versionCode 1
+        versionName "1.0"
+    }
+}
+
+dependencies {
+    implementation project(':permbus-api')
+    implementation project(':permbus-ui')
+    implementation 'androidx.core:core:1.12.0'
+}

--- a/appa/src/main/AndroidManifest.xml
+++ b/appa/src/main/AndroidManifest.xml
@@ -1,0 +1,17 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.appa">
+
+    <uses-permission android:name="android.permission.CAMERA" />
+
+    <application>
+        <activity android:name="com.example.permbus.ui.PermissionFixActivity"
+            android:exported="false" />
+
+        <service android:name=".PermissionPortalService"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="com.example.permbus.BIND_PERMISSION_PORTAL" />
+            </intent-filter>
+        </service>
+    </application>
+</manifest>

--- a/appa/src/main/java/com/example/appa/PermissionPortalService.java
+++ b/appa/src/main/java/com/example/appa/PermissionPortalService.java
@@ -1,0 +1,36 @@
+package com.example.appa;
+
+import android.app.Service;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.os.Binder;
+import android.os.IBinder;
+import android.Manifest;
+
+import com.example.permbus.IPermissionPortal;
+import com.example.permbus.PermInfo;
+import com.example.permbus.ui.PermissionFixActivity;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class PermissionPortalService extends Service {
+    private final IPermissionPortal.Stub binder = new IPermissionPortal.Stub() {
+        @Override
+        public List<PermInfo> getPendingPermissions() {
+            List<PermInfo> list = new ArrayList<>();
+            if (checkSelfPermission(Manifest.permission.CAMERA) != PackageManager.PERMISSION_GRANTED) {
+                Intent fix = new Intent(PermissionPortalService.this, PermissionFixActivity.class)
+                        .putExtra("perm", Manifest.permission.CAMERA);
+                String uri = fix.toUri(0);
+                list.add(new PermInfo(Manifest.permission.CAMERA, "Camera", uri));
+            }
+            return list;
+        }
+    };
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        return binder;
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,17 @@
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:8.5.0'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.22"
+    }
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,7 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+networkTimeout=10000
+validateDistributionUrl=true
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/launcher/build.gradle
+++ b/launcher/build.gradle
@@ -1,0 +1,34 @@
+plugins {
+    id 'com.android.application'
+    id 'org.jetbrains.kotlin.android'
+}
+
+android {
+    namespace 'com.example.launcherpoc'
+    compileSdk 34
+
+    defaultConfig {
+        applicationId 'com.example.launcherpoc'
+        minSdk 21
+        targetSdk 34
+        versionCode 1
+        versionName "1.0"
+    }
+
+    buildFeatures {
+        compose true
+    }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion '1.5.4'
+    }
+}
+
+dependencies {
+    implementation project(':permbus-api')
+    implementation 'androidx.core:core:1.12.0'
+    implementation platform('androidx.compose:compose-bom:2024.05.00')
+    implementation 'androidx.compose.ui:ui'
+    implementation 'androidx.compose.material3:material3'
+    implementation 'androidx.activity:activity-compose:1.9.0'
+}

--- a/launcher/src/main/AndroidManifest.xml
+++ b/launcher/src/main/AndroidManifest.xml
@@ -1,0 +1,13 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.launcherpoc">
+
+    <application>
+        <activity android:name=".MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/launcher/src/main/java/com/example/launcherpoc/MainActivity.kt
+++ b/launcher/src/main/java/com/example/launcherpoc/MainActivity.kt
@@ -1,0 +1,66 @@
+package com.example.launcherpoc
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.ServiceConnection
+import android.net.Uri
+import android.os.Bundle
+import android.os.IBinder
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import com.example.permbus.IPermissionPortal
+import androidx.compose.ui.platform.LocalContext
+import com.example.permbus.PermInfo
+
+class MainActivity : ComponentActivity() {
+    private var portal: IPermissionPortal? = null
+
+    private val connection = object : ServiceConnection {
+        override fun onServiceConnected(name: ComponentName?, service: IBinder?) {
+            portal = IPermissionPortal.Stub.asInterface(service)
+        }
+        override fun onServiceDisconnected(name: ComponentName?) {
+            portal = null
+        }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val intent = Intent("com.example.permbus.BIND_PERMISSION_PORTAL")
+        intent.`package` = "com.example.appa"
+        bindService(intent, connection, Context.BIND_AUTO_CREATE)
+
+        setContent {
+            PermissionList(portal)
+        }
+    }
+}
+
+@Composable
+fun PermissionList(portal: IPermissionPortal?) {
+    var list by remember { mutableStateOf<List<PermInfo>>(emptyList()) }
+    LaunchedEffect(portal) {
+        list = portal?.pendingPermissions ?: emptyList()
+    }
+
+    Column {
+        list.forEach { info ->
+            Text(text = info.uiLabel)
+            Button(onClick = {
+                val context = LocalContext.current
+                val intent = Intent.parseUri(info.fixIntentUri, 0)
+                context.startActivity(intent)
+            }) {
+                Text("Corregir")
+            }
+        }
+    }
+}
+
+private val IPermissionPortal.pendingPermissions: List<PermInfo>
+    get() = try { getPendingPermissions() } catch (e: Exception) { emptyList() }

--- a/permbus-api/build.gradle
+++ b/permbus-api/build.gradle
@@ -1,0 +1,15 @@
+plugins {
+    id 'com.android.library'
+}
+
+android {
+    namespace 'com.example.permbus'
+    compileSdk 34
+
+    defaultConfig {
+        minSdk 21
+    }
+}
+
+dependencies {
+}

--- a/permbus-api/src/main/aidl/com/example/permbus/IPermissionPortal.aidl
+++ b/permbus-api/src/main/aidl/com/example/permbus/IPermissionPortal.aidl
@@ -1,0 +1,7 @@
+package com.example.permbus;
+
+import com.example.permbus.PermInfo;
+
+interface IPermissionPortal {
+    List<PermInfo> getPendingPermissions();
+}

--- a/permbus-api/src/main/aidl/com/example/permbus/PermInfo.aidl
+++ b/permbus-api/src/main/aidl/com/example/permbus/PermInfo.aidl
@@ -1,0 +1,3 @@
+package com.example.permbus;
+
+parcelable PermInfo;

--- a/permbus-api/src/main/java/com/example/permbus/PermInfo.java
+++ b/permbus-api/src/main/java/com/example/permbus/PermInfo.java
@@ -1,0 +1,48 @@
+package com.example.permbus;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+public class PermInfo implements Parcelable {
+    public String permName;
+    public String uiLabel;
+    public String fixIntentUri;
+
+    public PermInfo() {}
+
+    public PermInfo(String permName, String uiLabel, String fixIntentUri) {
+        this.permName = permName;
+        this.uiLabel = uiLabel;
+        this.fixIntentUri = fixIntentUri;
+    }
+
+    protected PermInfo(Parcel in) {
+        permName = in.readString();
+        uiLabel = in.readString();
+        fixIntentUri = in.readString();
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeString(permName);
+        dest.writeString(uiLabel);
+        dest.writeString(fixIntentUri);
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    public static final Creator<PermInfo> CREATOR = new Creator<PermInfo>() {
+        @Override
+        public PermInfo createFromParcel(Parcel in) {
+            return new PermInfo(in);
+        }
+
+        @Override
+        public PermInfo[] newArray(int size) {
+            return new PermInfo[size];
+        }
+    };
+}

--- a/permbus-ui/build.gradle
+++ b/permbus-ui/build.gradle
@@ -1,0 +1,16 @@
+plugins {
+    id 'com.android.library'
+}
+
+android {
+    namespace 'com.example.permbus.ui'
+    compileSdk 34
+
+    defaultConfig {
+        minSdk 21
+    }
+}
+
+dependencies {
+    implementation 'androidx.core:core:1.12.0'
+}

--- a/permbus-ui/src/main/AndroidManifest.xml
+++ b/permbus-ui/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="com.example.permbus.ui"/>

--- a/permbus-ui/src/main/java/com/example/permbus/ui/PermissionFixActivity.java
+++ b/permbus-ui/src/main/java/com/example/permbus/ui/PermissionFixActivity.java
@@ -1,0 +1,24 @@
+package com.example.permbus.ui;
+
+import android.app.Activity;
+import android.os.Bundle;
+
+import androidx.core.app.ActivityCompat;
+
+public class PermissionFixActivity extends Activity {
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        String perm = getIntent().getStringExtra("perm");
+        if (perm != null) {
+            ActivityCompat.requestPermissions(this, new String[]{perm}, 1);
+        } else {
+            finish();
+        }
+    }
+
+    @Override
+    public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
+        finish();
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,8 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+rootProject.name = 'pocPermBus'
+include ':permbus-api', ':permbus-ui', ':appa', ':launcher'


### PR DESCRIPTION
## Summary
- add permbus-api library with AIDL and parcelable
- add permbus-ui library with simple activity to request permissions
- add appa sample app with service exposing CAMERA permission
- add launcher app showing missing permissions in Compose
- remove gradle wrapper jar

## Testing
- `gradle help --no-daemon`


------
https://chatgpt.com/codex/tasks/task_b_688bb779f2948325a1c3bac0ce88dd3d