### PR TITLE
Fix AndroidX build error

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+android.useAndroidX=true
+android.enableJetifier=true


### PR DESCRIPTION
## Summary
- add a `gradle.properties` file enabling AndroidX and Jetifier

## Testing
- `gradle help`

------
https://chatgpt.com/codex/tasks/task_b_688bc656147c83258acb4860d43e5a43