### PR TITLE
Fix Kotlin JVM target mismatch

### DIFF
--- a/launcher/build.gradle
+++ b/launcher/build.gradle
@@ -15,6 +15,15 @@ android {
         versionName "1.0"
     }
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+
     buildFeatures {
         compose true
     }


### PR DESCRIPTION
## Summary
- ensure launcher Kotlin compiles with Java 8

## Testing
- `gradle :launcher:assembleDebug --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_688bccdba628832581d36afcdee717f7