### PR TITLE
Adjust Kotlin version for Compose compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:8.5.0'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.22"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.20"
     }
 }
 


### PR DESCRIPTION
## Summary
- fix compatibility mismatch with Compose compiler

## Testing
- `gradle build -x test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_688c9c7ff61c8325827a019a5fee8eae