### PR TITLE
Add simple MainActivity to appa

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Este proyecto es una prueba de concepto de un _permission bus_ para Android. Consta de dos aplicaciones:
 
-- **appa**: expone un servicio que informa los permisos pendientes y permite lanzar la actividad para concederlos.
+ - **appa**: expone un servicio que informa los permisos pendientes y permite lanzar la actividad para concederlos. Ahora incluye una actividad principal sencilla para iniciar la app directamente.
 - **launcher**: cliente que se conecta al servicio de `appa` y ofrece una interfaz simple para solicitar los permisos desde otra app.
 
 ## Pasos para probar
@@ -15,6 +15,7 @@ Este proyecto es una prueba de concepto de un _permission bus_ para Android. Con
    gradle :launcher:installDebug
    ```
 4. Ejecuta la aplicación **LauncherPoC** en el dispositivo. Detectará los permisos que faltan en **appa** y mostrará un botón para corregirlos.
+5. Opcionalmente puedes abrir la app **appa** desde el lanzador para ver una pantalla de prueba.
 
 Con esto podrás verificar el funcionamiento básico del _permission bus_.
 

--- a/appa/src/main/AndroidManifest.xml
+++ b/appa/src/main/AndroidManifest.xml
@@ -4,6 +4,13 @@
     <uses-permission android:name="android.permission.CAMERA" />
 
     <application>
+        <activity android:name=".MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
         <activity android:name="com.example.permbus.ui.PermissionFixActivity"
             android:exported="false" />
 

--- a/appa/src/main/java/com/example/appa/MainActivity.java
+++ b/appa/src/main/java/com/example/appa/MainActivity.java
@@ -1,0 +1,16 @@
+package com.example.appa;
+
+import android.app.Activity;
+import android.os.Bundle;
+import android.widget.TextView;
+
+public class MainActivity extends Activity {
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        TextView tv = new TextView(this);
+        tv.setText("AppA main activity");
+        tv.setPadding(16, 16, 16, 16);
+        setContentView(tv);
+    }
+}


### PR DESCRIPTION
## Summary
- create a basic `MainActivity` for `appa`
- register the new activity in the manifest as MAIN/LAUNCHER
- document the new launcher in the README

## Testing
- `gradle build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_688ca3d9fc688325a5484ad2cec693b6