### PR TITLE
chore: refine permissionFlow publishing setup

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 android.useAndroidX=true
 android.enableJetifier=true
+permissionFlowVersion=1.0.0

--- a/permissionFlow/build.gradle
+++ b/permissionFlow/build.gradle
@@ -23,13 +23,46 @@ dependencies {
 publishing {
     publications {
         release(MavenPublication) {
-            groupId = 'com.example'
+            groupId = 'com.mycompany'
             artifactId = 'permission-flow'
-            version = '1.0'
+            version = project.findProperty("permissionFlowVersion")
+
+            pom {
+                description = "Android permission flow library"
+                licenses {
+                    license {
+                        name = "Apache-2.0"
+                        url = "https://www.apache.org/licenses/LICENSE-2.0.txt"
+                    }
+                }
+                developers {
+                    developer {
+                        id = "team"
+                        name = "Development Team"
+                        email = "devs@mycompany.com"
+                    }
+                }
+            }
         }
     }
     repositories {
         mavenLocal()
+        maven {
+            name = "Internal"
+            url = uri("https://maven.mycompany.com/" + (version.endsWith("SNAPSHOT") ? "snapshots" : "releases"))
+            credentials {
+                username = findProperty("internalMavenUser") ?: System.getenv("INTERNAL_MAVEN_USER")
+                password = findProperty("internalMavenPassword") ?: System.getenv("INTERNAL_MAVEN_PASSWORD")
+            }
+        }
+        maven {
+            name = "GitHubPackages"
+            url = uri("https://maven.pkg.github.com/my-org/pocPermBus")
+            credentials {
+                username = findProperty("githubUser") ?: System.getenv("GITHUB_ACTOR")
+                password = findProperty("githubToken") ?: System.getenv("GITHUB_TOKEN")
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- use corporate groupId and externalized version
- expand POM metadata with description, license, and developer info
- wire publishing repositories for internal Maven and GitHub Packages

## Testing
- `gradle :permissionFlow:publishToMavenLocal` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_689b9bd54bb083259a2b6f1cfdf7a520