### PR TITLE
Add permission flow tests and CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - name: Run tests
+        run: ./gradlew test --no-daemon

--- a/permissionFlow/build.gradle
+++ b/permissionFlow/build.gradle
@@ -11,6 +11,10 @@ android {
         minSdk 23
     }
 
+    buildFeatures {
+        aidl true
+    }
+
     publishing {
         singleVariant("release")
     }
@@ -18,6 +22,11 @@ android {
 
 dependencies {
     implementation 'androidx.core:core:1.12.0'
+
+    testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.robolectric:robolectric:4.10.3'
+    testImplementation 'org.mockito:mockito-core:5.4.0'
+    testImplementation 'androidx.test:core:1.5.0'
 }
 
 publishing {

--- a/permissionFlow/src/test/AndroidManifest.xml
+++ b/permissionFlow/src/test/AndroidManifest.xml
@@ -1,0 +1,14 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.permissionflow">
+
+    <uses-permission android:name="android.permission.CAMERA" />
+
+    <application>
+        <activity android:name=".ui.PermissionFixActivity" android:exported="false" />
+        <service android:name=".PermissionPortalService" android:exported="true">
+            <intent-filter>
+                <action android:name="com.example.permissionflow.BIND_PERMISSION_PORTAL" />
+            </intent-filter>
+        </service>
+    </application>
+</manifest>

--- a/permissionFlow/src/test/java/com/example/permissionflow/ContextCompatTest.java
+++ b/permissionFlow/src/test/java/com/example/permissionflow/ContextCompatTest.java
@@ -1,0 +1,32 @@
+package com.example.permissionflow;
+
+import android.Manifest;
+import android.app.Activity;
+import android.content.pm.PackageManager;
+
+import androidx.core.content.ContextCompat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.robolectric.RobolectricTestRunner;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Basic unit test that uses ContextCompat with a mocked Activity.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class ContextCompatTest {
+    @Test
+    public void checkSelfPermissionWithMockActivity() {
+        Activity activity = Mockito.mock(Activity.class);
+        Mockito.when(activity.checkSelfPermission(Manifest.permission.CAMERA))
+                .thenReturn(PackageManager.PERMISSION_DENIED);
+
+        int result = ContextCompat.checkSelfPermission(activity, Manifest.permission.CAMERA);
+
+        assertEquals(PackageManager.PERMISSION_DENIED, result);
+        Mockito.verify(activity).checkSelfPermission(Manifest.permission.CAMERA);
+    }
+}

--- a/permissionFlow/src/test/java/com/example/permissionflow/PermissionPortalServiceTest.java
+++ b/permissionFlow/src/test/java/com/example/permissionflow/PermissionPortalServiceTest.java
@@ -1,0 +1,54 @@
+package com.example.permissionflow;
+
+import static org.junit.Assert.assertEquals;
+
+import android.Manifest;
+import android.content.Intent;
+
+import android.app.Application;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import com.example.permissionflow.ui.PermissionFixActivity;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.Shadows;
+import org.robolectric.shadows.ShadowApplication;
+
+import java.util.List;
+
+/**
+ * Tests for {@link PermissionPortalService} using Robolectric.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class PermissionPortalServiceTest {
+
+    private PermissionPortalService service;
+
+    @Before
+    public void setUp() {
+        service = Robolectric.buildService(PermissionPortalService.class).create().get();
+        Application app = ApplicationProvider.getApplicationContext();
+        ShadowApplication shadow = Shadows.shadowOf(app);
+        shadow.denyPermissions(Manifest.permission.CAMERA);
+    }
+
+    @Test
+    public void reportsDeniedPermissions() throws Exception {
+        Intent bind = new Intent(PermissionPortalService.BIND_PERMISSION_PORTAL);
+        IPermissionPortal portal = IPermissionPortal.Stub.asInterface(service.onBind(bind));
+
+        List<PermInfo> list = portal.getPendingPermissions();
+        assertEquals(1, list.size());
+
+        PermInfo info = list.get(0);
+        assertEquals(Manifest.permission.CAMERA, info.permName);
+        Intent fixIntent = Intent.parseUri(info.fixIntentUri, 0);
+        assertEquals(PermissionFixActivity.class.getName(), fixIntent.getComponent().getClassName());
+        assertEquals(Manifest.permission.CAMERA, fixIntent.getStringExtra("perm"));
+    }
+}

--- a/permissionFlow/src/test/java/com/example/permissionflow/ui/PermissionFixActivityTest.java
+++ b/permissionFlow/src/test/java/com/example/permissionflow/ui/PermissionFixActivityTest.java
@@ -1,0 +1,49 @@
+package com.example.permissionflow.ui;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertTrue;
+
+import android.Manifest;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+
+import androidx.core.content.ContextCompat;
+import androidx.test.core.app.ApplicationProvider;
+
+import com.example.permissionflow.ui.PermissionFixActivity;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.Shadows;
+import org.robolectric.shadows.ShadowActivity;
+
+/**
+ * Tests for {@link PermissionFixActivity} using Robolectric.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class PermissionFixActivityTest {
+
+    @Test
+    public void requestsPermissionWhenExtraPresent() {
+        Intent intent = new Intent(ApplicationProvider.getApplicationContext(), PermissionFixActivity.class);
+        intent.putExtra("perm", Manifest.permission.CAMERA);
+
+        PermissionFixActivity activity = Robolectric.buildActivity(PermissionFixActivity.class, intent)
+                .create().get();
+        ShadowActivity shadow = Shadows.shadowOf(activity);
+        ShadowActivity.PermissionsRequest request = shadow.getLastRequestedPermission();
+
+        assertArrayEquals(new String[]{Manifest.permission.CAMERA}, request.requestedPermissions);
+        // Permission should still be denied at this point
+        int status = ContextCompat.checkSelfPermission(activity, Manifest.permission.CAMERA);
+        assertTrue(status == PackageManager.PERMISSION_DENIED);
+    }
+
+    @Test
+    public void finishesWhenNoPermissionExtra() {
+        PermissionFixActivity activity = Robolectric.buildActivity(PermissionFixActivity.class).create().get();
+        assertTrue(activity.isFinishing());
+    }
+}


### PR DESCRIPTION
## Summary
- enable AIDL processing and add test dependencies for permissionFlow
- add Robolectric-based tests for permission flow components and ContextCompat usage
- configure GitHub Actions workflow to run the test suite

## Testing
- `gradle :permissionFlow:test` *(fails: failing tests)*

------
https://chatgpt.com/codex/tasks/task_b_689b9ec505a483258ee340c3f49a9422